### PR TITLE
Add explicit target to Podfile

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -2,5 +2,7 @@ platform :ios, '7.1'
 
 xcodeproj 'RNBranch/RNBranch.xcodeproj'
 
-pod 'Branch'
+target "RNBranch" do
+	pod 'Branch'
+end
 


### PR DESCRIPTION
Newest version of CocoaPods yelled at me because it wasn't finding an explicit target. I'm unsure if this is backwards compatible but I don't see why it wouldn't be.
